### PR TITLE
Updating original Atlas bling to work with new LED strip

### DIFF
--- a/2014-Atlas-NeoPixel/2014-Atlas-NeoPixel.ino
+++ b/2014-Atlas-NeoPixel/2014-Atlas-NeoPixel.ino
@@ -10,7 +10,7 @@
 #include "FastLED.h"
 
 // How many leds on your strip?
-#define NUM_LEDS 8
+#define NUM_LEDS 150
 
 // For led chips like Neopixels, which have a data line, ground, and power,
 // you just need to define DATA_PIN.  For led chipsets that are SPI based


### PR DESCRIPTION
Our "modernized" original Atlas Bling program was configured for the wrong number of LEDs on the strip.

With this change, the 2014-Atlas-NeoPixel project will run correctly on the rebuilt Atlas robot.